### PR TITLE
Remove carregamento assíncrono de CSS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,8 +43,7 @@
 
     <meta name="theme-color" content="#2b5797">
 
-    <link href="{{ "/css/main.css" | prepend: site.baseurl }}" rel="prefetch" media="all" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}"></noscript>
+    <link href="{{ "/css/main.css" | prepend: site.baseurl }}" rel="stylesheet">
 
     <link rel="preload" as="font" href="https://fonts.googleapis.com/css?family=Roboto&display=swap" type="font/woff2" crossorigin="anonymous">
 

--- a/index.html
+++ b/index.html
@@ -15,5 +15,4 @@ permalink: /
  {% include location-map.html %}
 {% endcomment %}
 
-<link rel="preload" href="{{ "/css/home.css" | prepend: site.baseurl }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<noscript><link rel="stylesheet" href="{{ "/css/home.css" | prepend: site.baseurl }}"></noscript>
+<link href="{{ "/css/home.css" | prepend: site.baseurl }}" rel="stylesheet">


### PR DESCRIPTION
O carregamento assíncrono de CSS sugerido em https://web.dev/defer-non-critical-css/#optimize não funciona no Firefox, o CSS não está sendo carregado nem via fallback 😢 

Esse PR remove esse código temporariamente para evitar erros de renderização no Firefox.

**Antes**:

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/9295389/70910150-e6e99780-1fed-11ea-8dfe-3b66ed487155.png">

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/9295389/70910180-f23cc300-1fed-11ea-8b73-43c87f2881f5.png">

**Depois**:

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/9295389/70910236-100a2800-1fee-11ea-9c35-b4547b61c467.png">

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/9295389/70910269-27491580-1fee-11ea-8942-b6b307f3f7ea.png">

**Como testar**

Abra o site no Firefox e cheque se a página inicial do site renderiza normalmente.
